### PR TITLE
add first 'sketch' of a testing—environment

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,10 +1,29 @@
 {
-	"name": "ViaRE",
+	"name": "viare",
+	"targetName" : "ViaRE",
 	"authors": [
 		"bitobs",
 		"davidomarf"
 	],
 	"description": "ViaRE is a Real Emulation",
 	"copyright": "Copyright © 2018",
-	"license": "MIT"
+	"license": "MIT",
+	"configurations": [
+        {
+            "name": "application",
+            "targetType": "executable"
+        },
+        {
+			"name": "unittest",
+            "targetType": "executable",
+            "targetPath" : "tests",
+            "buildOptions": ["unittests"],
+            "excludedSourceFiles": ["source/app.d"],
+            "sourcePaths": ["tests/"],
+            "importPaths": ["tests/"],
+            "dependencies": {
+                "dunit": ">=1.0.9"
+            }
+        }
+    ]
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dunit": "1.0.14"
+	}
+}

--- a/source/geometry.d
+++ b/source/geometry.d
@@ -1,5 +1,6 @@
-// This will do something tricky and spoooooooky 
-import std.traits;
+import  std.traits,
+        std.math,
+        std.stdio;
 
 /*
 Template for Vector types.
@@ -9,3 +10,17 @@ if(isNumeric!T) // only defined if T is a numeric type.
 {
     T x, y, z;
 };
+
+/***********************************
+ * Returns (for now, just for the sake of Miguelito to see this) 2.2
+ * 
+ * Params:
+ *      a =     Array of reals. Size s.
+ *      b =     Array of reals. Size s.
+ *
+ * Returns:
+ *      d =     Euclidean distance between a and b.
+ */
+double euclideanDistance(real[] a, real[] b){
+    return 2.2;
+}

--- a/tests/geometry_test.d
+++ b/tests/geometry_test.d
@@ -1,0 +1,10 @@
+import geometry;
+
+// Just one import, but one unittest for every "important"
+// aspect implemented in the imported module
+
+unittest
+{
+    assert( euclideanDistance([1, 2], [3, 4]) == 2.2 );
+    assert( Vector!int(1, 2, 3).y == 2);
+}

--- a/tests/main.d
+++ b/tests/main.d
@@ -1,0 +1,5 @@
+module main;
+void main(){}
+
+import geometry_test;
+// import all test-modules;


### PR DESCRIPTION
## Description
- Update dub.json to ignore source folder and compile only `tests/` directory when `dub test` is called.
- Implement `euclideanDistance` that will always return 2.2 in `source/geometry.d`
- Create `main.d` in `tests/`
- **Current implementation generetes a warning:**

```
## Warning for package viare, configuration unittest ##

The following compiler flags have been specified in the package description
file. They are handled by DUB and direct use in packages is discouraged.
Alternatively, you can set the DFLAGS environment variable to pass custom flags
to the compiler, or use one of the suggestions below:

unittests: Call DUB with --build=unittest
```

## Related Issue
#10 

## Motivation and Context
Ease further development using automated tests.

## How Has This Been Tested?

- Running `dub test` in root directory. **When all tests passed, no output is given.**

- Environment
  - DUB version 1.8.0.
  - DMD32 D Compiler v2.079.0

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
