### PR TITLE
Remove toy function implemented when trying unit testing

### DIFF
--- a/source/geometry.d
+++ b/source/geometry.d
@@ -12,17 +12,3 @@ if(isNumeric!T) // only defined if T is a numeric type.
 {
     T x, y, z;
 };
-
-/***********************************
- * Returns (for now, just for the sake of Miguelito to see this) 2.2
- * 
- * Params:
- *      a =     Array of reals. Size s.
- *      b =     Array of reals. Size s.
- *
- * Returns:
- *      d =     Euclidean distance between a and b.
- */
-double euclideanDistance(real[] a, real[] b){
-    return 2.2;
-}


### PR DESCRIPTION
Remove euclideanDistance in geometry.d, as it was useless. A proper
implementation may be done in the future, but for now it serves no
purpose.