### PR TITLE
Fix SDL2 library errors about missing .so files

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,9 +1,9 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"derelict-gl3": "2.0.0-beta.6",
-		"derelict-sdl2": "3.0.0-beta.7",
+		"derelict-sdl2": "3.1.0-alpha.3",
 		"derelict-util": "3.0.0-beta.2",
-		"dunit": "1.0.14"
+		"dunit": "1.0.14",
+		"derelict-gl3": "2.0.0-beta.6"
 	}
 }

--- a/source/graphics.d
+++ b/source/graphics.d
@@ -24,7 +24,7 @@ import viare.geometry;
 */
 static this()
 {
-    DerelictSDL2.load();
+    DerelictSDL2.load(SharedLibVersion(2, 0, 2));
     DerelictGL3.load();
 
     if(SDL_Init(SDL_INIT_EVERYTHING) < 0)


### PR DESCRIPTION
## Description
Before this fix, running the app would throw errors about failing loads from library `libSDL2.so`:

```
derelict.util.exception.SymbolLoadException@../../../.dub/packages/derelict-util-3.0.0-beta.2/source/derelict/util/sharedlib.d(181): Failed to load symbol SDL_DequeueAudio from shared library libSDL2.so

Program exited with code 1
```
After finding a [related problem](https://stackoverflow.com/a/37903107), I decided to specify the library version to be used, and it worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

**NOTE**: This, however, made evident another problem:

```
GLSL 3.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.40, 1.00 ES, and 3.00 ES
```
Details about that problem will be opened in a new issue.
I can assure: This new problem isn't a consequence of this fix.