### PR TITLE
Fix context version specification of GL3

### DIFF
--- a/shaders/test.glsl
+++ b/shaders/test.glsl
@@ -1,4 +1,4 @@
-#version 330 core
+#version 330 core 
 
 layout (location = 0) in vec3 aPos;
 

--- a/source/graphics.d
+++ b/source/graphics.d
@@ -64,7 +64,11 @@ class Window
     */
 	this(string name, uint width, uint height)
 	{
-	    m_window = SDL_CreateWindow(name.toStringz(),
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE); 
+	    
+            m_window = SDL_CreateWindow(name.toStringz(),
 		SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
 		width, height,
 		SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL);


### PR DESCRIPTION
## Description
Sets GL context version before creating the window using `SDL_GL_SetAttribute()` to specify `SDL_GL_CONTEXT_MAJOR_VERSION`, `SDL_GL_CONTEXT_MINOR_VERSION`, and `SDL_GL_CONTEXT_PROFILE_MASK`.

## Related Issue
#19 

## How Has This Been Tested?
- Intel HD 4000
- Elementary OS Loki
- DUB 0.9.24-2
- DMD v2.079.0
- OpenGL core profile version string: 4.2 (Core Profile) Mesa 18.1.0-devel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)